### PR TITLE
Fix(sampledata): Set referential action in foreign key definition

### DIFF
--- a/form-backend/form_configs/fountains_advanced.json
+++ b/form-backend/form_configs/fountains_advanced.json
@@ -164,8 +164,8 @@
     "item": true
   },
   "access": {
-    "read": true,
-    "write": true
+    "read": ["fountains_editor"],
+    "write": ["fountains_editor"]
   },
   "includedProperties": [
     "id",

--- a/form-backend/form_configs/fountains_minimal.json
+++ b/form-backend/form_configs/fountains_minimal.json
@@ -9,6 +9,6 @@
   },
   "access": {
     "read": true,
-    "write": ["fountains_editor"]
+    "write": false
   }
 }

--- a/postgres/init_data/01_init_sampledata.sql
+++ b/postgres/init_data/01_init_sampledata.sql
@@ -216,18 +216,18 @@ ALTER TABLE ONLY sampledata.fountains
 
 
 ALTER TABLE ONLY sampledata.fountains_contacts
-    ADD CONSTRAINT fountains_contacts_fk FOREIGN KEY (fountain_id) REFERENCES sampledata.fountains(id);
+    ADD CONSTRAINT fountains_contacts_fk FOREIGN KEY (fountain_id) REFERENCES sampledata.fountains(id) ON DELETE CASCADE;
 
 
 ALTER TABLE ONLY sampledata.fountains_contacts
-    ADD CONSTRAINT fountains_contacts_fk_1 FOREIGN KEY (contact_id) REFERENCES sampledata.contacts(id);
+    ADD CONSTRAINT fountains_contacts_fk_1 FOREIGN KEY (contact_id) REFERENCES sampledata.contacts(id) ON DELETE CASCADE;
 
 
 ALTER TABLE ONLY sampledata.fountains
-    ADD CONSTRAINT fountains_fk FOREIGN KEY (type) REFERENCES sampledata.fountain_types(id);
+    ADD CONSTRAINT fountains_fk FOREIGN KEY (type) REFERENCES sampledata.fountain_types(id) ON DELETE SET NULL;
 
 ALTER TABLE ONLY sampledata.fountains_pictures
-    ADD CONSTRAINT fountains_pictures_fk FOREIGN KEY (fountain_id) REFERENCES sampledata.fountains(id);
+    ADD CONSTRAINT fountains_pictures_fk FOREIGN KEY (fountain_id) REFERENCES sampledata.fountains(id) ON DELETE CASCADE;
 
 
 CREATE TABLE sampledata.inspections (
@@ -248,7 +248,7 @@ ALTER TABLE ONLY sampledata.inspections
     ADD CONSTRAINT inspections_pk PRIMARY KEY (id);
 
 ALTER TABLE ONLY sampledata.inspections
-    ADD CONSTRAINT fountains_fk_1 FOREIGN KEY (fountain_id) REFERENCES sampledata.fountains(id);
+    ADD CONSTRAINT fountains_fk_1 FOREIGN KEY (fountain_id) REFERENCES sampledata.fountains(id) ON DELETE CASCADE;
 
 CREATE SEQUENCE sampledata.inspections_id_seq
     AS integer
@@ -278,7 +278,7 @@ ALTER TABLE ONLY sampledata.inspections_contacts
     ADD CONSTRAINT inspections_contacts_un UNIQUE (inspection_id, contact_id);
 
 ALTER TABLE ONLY sampledata.inspections_contacts
-    ADD CONSTRAINT inspections_contacts_fk FOREIGN KEY (inspection_id) REFERENCES sampledata.inspections(id);
+    ADD CONSTRAINT inspections_contacts_fk FOREIGN KEY (inspection_id) REFERENCES sampledata.inspections(id) ON DELETE CASCADE;
 
 ALTER TABLE ONLY sampledata.inspections_contacts
-    ADD CONSTRAINT inspections_contacts_fk_1 FOREIGN KEY (contact_id) REFERENCES sampledata.contacts(id);
+    ADD CONSTRAINT inspections_contacts_fk_1 FOREIGN KEY (contact_id) REFERENCES sampledata.contacts(id) ON DELETE CASCADE;


### PR DESCRIPTION
See title.

Herewith, deletion of sampledata entries is fixed (e.g. those used in `fountains.json` config) for which a foreign key constraint is active.

Beside, the `read` and `write` role has been adapted to the roles defined in database for minimal and advanced config.

Plz review @hblitza @jansule 